### PR TITLE
feat(LINGUIST-486): Only valid words can be added

### DIFF
--- a/src/main/java/app/linguistai/bmvp/consts/Parameter.java
+++ b/src/main/java/app/linguistai/bmvp/consts/Parameter.java
@@ -2,4 +2,5 @@ package app.linguistai.bmvp.consts;
 
 public class Parameter {
     public static final String ASCENDING_ORDER = "asc";
+    public static final boolean ALLOW_ADDING_NON_DICTIONARY_WORDS = false;
 }

--- a/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
@@ -26,6 +26,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static app.linguistai.bmvp.consts.Parameter.ALLOW_ADDING_NON_DICTIONARY_WORDS;
+
 @AllArgsConstructor
 @RestController
 @RequestMapping("wordbank")
@@ -63,8 +65,8 @@ public class UnknownWordController {
     }
 
     @PostMapping("/add-word")
-    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email, @RequestParam(defaultValue = "false") boolean allowUnknown) throws Exception {
-        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email, allowUnknown));
+    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email) throws Exception {
+        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email, ALLOW_ADDING_NON_DICTIONARY_WORDS));
     }
 
     @PostMapping("/increase-confidence")

--- a/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
@@ -63,16 +63,8 @@ public class UnknownWordController {
     }
 
     @PostMapping("/add-word")
-    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email) {
-        try {
-            return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email));
-        }
-        catch (RuntimeException e) {
-            return Response.create(e.getMessage(), HttpStatus.BAD_REQUEST);
-        }
-        catch (Exception e) {
-            return Response.create("Could not add unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email) throws Exception {
+        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email));
     }
 
     @PostMapping("/increase-confidence")

--- a/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
@@ -63,8 +63,8 @@ public class UnknownWordController {
     }
 
     @PostMapping("/add-word")
-    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email) throws Exception {
-        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email));
+    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email, @RequestParam(defaultValue = "false") boolean allowUnknown) throws Exception {
+        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email, allowUnknown));
     }
 
     @PostMapping("/increase-confidence")

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
@@ -17,7 +17,7 @@ public interface IUnknownWordService {
     RUnknownWordListWords getListWithWordsById(UUID listId, String email) throws Exception;
     ROwnerUnknownWordList createList(QUnknownWordList qUnknownWordList, String email) throws Exception;
     ROwnerUnknownWordList editList(UUID listId, QUnknownWordList qUnknownWordList, String email) throws Exception;
-    RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowUnknown) throws Exception;
+    RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowNonDictionaryWords) throws Exception;
     RUnknownWord increaseConfidence(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
     RUnknownWord decreaseConfidence(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
     ROwnerUnknownWordList activateList(UUID listId, String email) throws Exception;

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
@@ -17,7 +17,7 @@ public interface IUnknownWordService {
     RUnknownWordListWords getListWithWordsById(UUID listId, String email) throws Exception;
     ROwnerUnknownWordList createList(QUnknownWordList qUnknownWordList, String email) throws Exception;
     ROwnerUnknownWordList editList(UUID listId, QUnknownWordList qUnknownWordList, String email) throws Exception;
-    RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
+    RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowUnknown) throws Exception;
     RUnknownWord increaseConfidence(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
     RUnknownWord decreaseConfidence(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
     ROwnerUnknownWordList activateList(UUID listId, String email) throws Exception;

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
@@ -276,7 +276,7 @@ public class UnknownWordService implements IUnknownWordService {
                 throw new NotFoundException(String.format("It looks like %s isn't in our dictionary yet. Please double-check your spelling.", qAddUnknownWord.getWord()));
             }
             log.error("Dictionary service returned an error:" + e.getMessage());
-            throw new SomethingWentWrongException();
+            throw new SomethingWentWrongException("We had trouble communicating with our dictionary service, please try again later.");
         } catch (RuntimeException e) {
             log.error(e.getMessage());
             throw new AlreadyFoundException(e.getMessage());

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
@@ -226,7 +226,7 @@ public class UnknownWordService implements IUnknownWordService {
 
     @Override
     @Transactional
-    public RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowUnknown) throws Exception {
+    public RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowNonDictionaryWords) throws Exception {
         try {
             // Check if dictionary service base URL is set
             if (DICT_SERVICE_BASE_URL == null || DICT_SERVICE_BASE_URL.isEmpty()) {
@@ -247,8 +247,8 @@ public class UnknownWordService implements IUnknownWordService {
                 throw new RuntimeException("Word " + qAddUnknownWord.getWord().toLowerCase() + " already exists in list " + userList.getTitle() + ".");
             });
 
-            // Call dictionary service only if allowUnknown is false
-            if (!allowUnknown) {
+            // Call dictionary service only if allowNonDictionaryWords is false
+            if (!allowNonDictionaryWords) {
                 Map<String, Object> requestBody = new HashMap<>();
                 requestBody.put("wordList", Collections.singletonList(qAddUnknownWord.getWord().toLowerCase()));
 

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
@@ -273,7 +273,7 @@ public class UnknownWordService implements IUnknownWordService {
         } catch (WebClientResponseException e) {
             if (e.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
                 log.error("Word {} is not found in the dictionary.", qAddUnknownWord.getWord());
-                throw new NotFoundException(String.format("Word %s is not valid.", qAddUnknownWord.getWord()));
+                throw new NotFoundException(String.format("It looks like %s isn't in our dictionary yet. Please double-check your spelling.", qAddUnknownWord.getWord()));
             }
             log.error("Dictionary service returned an error:" + e.getMessage());
             throw new SomethingWentWrongException();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,7 @@ spring.jwt.access.expiration=${JWT_ACCESS_VALID_MINUTES}
 spring.jwt.refresh.expiration=${JWT_REFRESH_VALID_MINUTES}
 
 ml.service.base.url=${ML_SERVICE_BASE_URL}
+dict.service.base.url=${DICT_SERVICE_BASE_URL}
 
 # Level configs
 xp.values.message=1

--- a/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
+++ b/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
@@ -367,7 +367,7 @@ class UnknownWordServiceTest {
         when(accountRepository.findUserByEmail("email")).thenReturn(Optional.empty());
 
         // Run the test
-        assertThatThrownBy(() -> unknownWordService.addWord(qAddUnknownWord, "email"))
+        assertThatThrownBy(() -> unknownWordService.addWord(qAddUnknownWord, "email", true))
             .isInstanceOf(Exception.class);
     }
 
@@ -390,7 +390,7 @@ class UnknownWordServiceTest {
             .thenReturn(Optional.empty());
 
         // Run the test
-        assertThatThrownBy(() -> unknownWordService.addWord(qAddUnknownWord, "email"))
+        assertThatThrownBy(() -> unknownWordService.addWord(qAddUnknownWord, "email", true))
             .isInstanceOf(Exception.class);
     }
 

--- a/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
+++ b/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
@@ -12,11 +12,14 @@ import app.linguistai.bmvp.repository.wordbank.IUnknownWordRepository;
 import app.linguistai.bmvp.request.wordbank.QAddUnknownWord;
 import app.linguistai.bmvp.request.wordbank.QUnknownWordList;
 import app.linguistai.bmvp.response.wordbank.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +42,13 @@ class UnknownWordServiceTest {
     private IUnknownWordListRepository listRepository;
     @Mock
     private IAccountRepository accountRepository;
+
+    private static final String DICT_SERVICE_BASE_URL = "http://example.com/dictionary";
+
+    @BeforeEach
+    public void setUp() {
+        ReflectionTestUtils.setField(unknownWordService, "DICT_SERVICE_BASE_URL", DICT_SERVICE_BASE_URL);
+    }
 
     @Test
     void testGetListsByEmail() throws Exception {


### PR DESCRIPTION
When adding a new word, send a sync request to the dictionary to check if the word is valid.

secrets.properties should be changed to include:  (I will update the confluence page after merge)

`DICT_SERVICE_BASE_URL=http://localhost:8082/api/v1/dictionary`

I am not sure if this would work on the server though. @tolgaozgun 