### PR TITLE
feat(LINGUIST-533): Register Device Tokens Upon User Registration  && Trigger AWS Lambda's When User Level's Up 

### DIFF
--- a/src/main/java/app/linguistai/bmvp/consts/ServiceUris.java
+++ b/src/main/java/app/linguistai/bmvp/consts/ServiceUris.java
@@ -6,4 +6,6 @@ import lombok.experimental.UtilityClass;
 public class ServiceUris {
     public static final String ML_SERVICE_PROFILE_APP = "/profile";
     public static final String ML_SERVICE_UPDATE_PROFILE = ML_SERVICE_PROFILE_APP + "/update";
+    public static final String AWS_SERVICE_REGISTER_TO_SNS = "/sns";
+    public static final String AWS_SERVICE_SEND_NOTIFICATION = AWS_SERVICE_REGISTER_TO_SNS + "/send-notification";
 }

--- a/src/main/java/app/linguistai/bmvp/request/QUser.java
+++ b/src/main/java/app/linguistai/bmvp/request/QUser.java
@@ -19,4 +19,7 @@ public class QUser {
     @Pattern(regexp = "^(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).*$", 
     message = "Password must contain at least one uppercase letter, one number, and one special character")
     private String password;
+
+    
+    private String fcmToken;
 }

--- a/src/main/java/app/linguistai/bmvp/service/AccountService.java
+++ b/src/main/java/app/linguistai/bmvp/service/AccountService.java
@@ -1,7 +1,9 @@
 package app.linguistai.bmvp.service;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -22,14 +24,18 @@ import app.linguistai.bmvp.service.profile.ProfileService;
 import app.linguistai.bmvp.service.stats.UserLoggedDateService;
 import app.linguistai.bmvp.service.wordbank.UnknownWordService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import app.linguistai.bmvp.model.User;
+import app.linguistai.bmvp.consts.Header;
+import app.linguistai.bmvp.consts.ServiceUris;
 import app.linguistai.bmvp.enums.UserSearchFriendshipStatus;
 import app.linguistai.bmvp.repository.IAccountRepository;
 import app.linguistai.bmvp.request.QChangePassword;
@@ -45,6 +51,8 @@ import app.linguistai.bmvp.service.gamification.UserStreakService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
 import static app.linguistai.bmvp.consts.FilePaths.DEFAULT_WORD_LIST_FILE;
 
 @Slf4j
@@ -70,6 +78,19 @@ public class AccountService {
     private final IXPService xpService;
     private final IQuestService questService;
     private final ProfileService profileService;
+
+    private WebClient webClient;
+    private final WebClient.Builder webClientBuilder;
+
+    @Value("${aws.service.base.url}")
+    private String AWS_SERVICE_BASE_URL;
+
+    private WebClient getWebClient() {
+        if (webClient == null) {
+            webClient = webClientBuilder.baseUrl(AWS_SERVICE_BASE_URL).build();
+        }
+        return webClient;
+    }
 
     public RLoginUser login(QUserLogin user) throws Exception {
         try {
@@ -216,7 +237,31 @@ public class AccountService {
             xpService.createUserXPForRegister(newUser);
             profileService.createEmptyProfile(newUser);
             unknownWordService.addPredefinedWordList(DEFAULT_WORD_LIST_FILE, newUser.getEmail());
-          
+
+            String fcmToken = requestUser.getFcmToken();
+            boolean isTokenValid = fcmToken != null && !fcmToken.isEmpty();
+            // Only register to SNS if fcmToken actually exists
+            if (isTokenValid) {
+                Map<String, Object> requestBody = new HashMap<>();
+                requestBody.put("fcmToken", fcmToken);
+                requestBody.put("userId", newUser.getId().toString());
+                this.getWebClient().post()
+                    .uri(ServiceUris.AWS_SERVICE_REGISTER_TO_SNS)
+                    .header(Header.USER_EMAIL, newUser.getEmail())
+                    .body(Mono.just(requestBody), Map.class)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .subscribe(response -> {
+                        if (response != null) {
+                            log.info("register to SNS - Response from AWS service: " + response);
+                        }
+                    }, error -> {
+                        if (error != null) {
+                            log.error("register to SNS - Error from AWS service: " + error.getMessage());
+                        }
+                    });
+            }
+
             // Create access and reset tokens so that user does not have to log in after registering
             final UserDetails userDetails = jwtUserService.loadUserByUsername(newUser.getEmail());
             final String accessToken = jwtUtils.createAccessToken(userDetails);

--- a/src/main/java/app/linguistai/bmvp/service/gamification/XPService.java
+++ b/src/main/java/app/linguistai/bmvp/service/gamification/XPService.java
@@ -127,8 +127,7 @@ public class XPService implements IXPService {
             UserXPWithLevel newLevelInfo = this.determineProceduralLevel(updated.getExperience());
             Long userLevel = newLevelInfo.level();
             Long xpToNextLevel = newLevelInfo.totalExperienceToNextLevel();
-
-            notifyUserLevelUp(previousLevel, user, userLevel);
+            this.notifyUserLevelUp(previousLevel, user, userLevel);
 
             log.info("User XP increased from {} to {} for user {}", userXP.getExperience(), updated.getExperience(), user.getId());
             return RUserXP.builder()

--- a/src/main/java/app/linguistai/bmvp/service/gamification/XPService.java
+++ b/src/main/java/app/linguistai/bmvp/service/gamification/XPService.java
@@ -47,7 +47,7 @@ public class XPService implements IXPService {
     @Value("${aws.service.base.url}")
     private String AWS_SERVICE_BASE_URL;
 
-    private WebClient getWebClient() {
+    private WebClient getXpServiceWebClient() {
         if (xpServiceWebClient == null) {
             xpServiceWebClient = xpServiceWebClientBuilder.baseUrl(AWS_SERVICE_BASE_URL).build();
         }
@@ -172,7 +172,7 @@ public class XPService implements IXPService {
             requestBody.put("notificationMessage", "Congrats, you've leveled up to level " + userLevel + "!");
             requestBody.put("data", data);                
 
-            this.getWebClient().post()
+            this.getXpServiceWebClient().post()
                 .uri(ServiceUris.AWS_SERVICE_SEND_NOTIFICATION)
                 .header(Header.USER_EMAIL, user.getEmail())
                 .body(Mono.just(requestBody), Map.class)

--- a/src/main/java/app/linguistai/bmvp/service/gamification/XPService.java
+++ b/src/main/java/app/linguistai/bmvp/service/gamification/XPService.java
@@ -130,12 +130,23 @@ public class XPService implements IXPService {
 
             // Send level up event to AWS
             if (userLevel > previousLevel) {
-            // Only register to SNS if fcmToken actually exists
                 Map<String, Object> requestBody = new HashMap<>();
+
+                // Select target users
                 List<String> targetUsers = new ArrayList<String>();
+                targetUsers.add(user.getId().toString());
+                
+                // Prepare data for notification
+                Map<String, Object> data = new HashMap<>();
+                data.put("type", "LevelUp");
+                data.put("previousLevel", previousLevel);
+                data.put("currentLevel", userLevel);
+                
+                // Prepare request body
                 requestBody.put("userIds", targetUsers);
-                requestBody.put("type", "LevelUp");
-                requestBody.put("message", "newUser.getId().toString()");
+                requestBody.put("title", "Level Up!");
+                requestBody.put("notificationMessage", "Congrats, you've leveled up to level " + userLevel + "!");
+                requestBody.put("data", data);                
 
                 this.getWebClient().post()
                     .uri(ServiceUris.AWS_SERVICE_SEND_NOTIFICATION)
@@ -152,10 +163,10 @@ public class XPService implements IXPService {
                             log.error("Failed to send LevelUp Notification to SNS - Error from AWS service: " + error.getMessage());
                         }
                     });
-
                 log.info("User {} leveled up to new level {} from level {}", user.getId(), userLevel, previousLevel);
             }
 
+            log.info("User XP increased from {} to {} for user {}", userXP.getExperience(), updated.getExperience(), user.getId());
             return RUserXP.builder()
                 .username(user.getUsername())
                 .currentExperience(updated.getExperience())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Server port
-server.port=8081
+server.port=8082
 
 spring.profiles.active=${ACTIVE_ENV:dev}
 
@@ -40,6 +40,7 @@ spring.jwt.access.expiration=${JWT_ACCESS_VALID_MINUTES}
 spring.jwt.refresh.expiration=${JWT_REFRESH_VALID_MINUTES}
 
 ml.service.base.url=${ML_SERVICE_BASE_URL}
+aws.service.base.url=${AWS_SERVICE_BASE_URL}
 
 # Level configs
 xp.values.message=1

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Server port
-server.port=8082
+server.port=8081
 
 spring.profiles.active=${ACTIVE_ENV:dev}
 


### PR DESCRIPTION
- Added AWS endpoints to `ServiceUris` file.
- Added `fcmToken` to the request body for user registration
- Created a private function called `registerToSNS` in `AccountService` which sends the `fcmToken` (Firebase Cloud Messaging Token) of the registering device to the relevant Lambda function. The lambda generates a unique SNS application endpoint and saves the `endpoint`, `userId`, and `deviceToken` to a `DynamoDB` table.
  - If no fcmToken is received, we don't register the device for sending notifications at all. We may need to add additional checks during login for when the `deviceToken` of the user may change.
- Created a private function called `notifyUserLevelUp` which sends a notification to the user who just leveled up (if they leveled up) via a Lambda function defined on AWS.

> [!Caution]
> A new `secrets.properties` property must be added for proper configuration. The updated secrets.properties file is available in the [relevant confluence page](https://linguistai.atlassian.net/wiki/spaces/LINGUIST/pages/1867777/Secrets+Properties)