### PR TITLE
refactor(LINGUIST-486): Log dictionary's response

### DIFF
--- a/src/main/java/app/linguistai/bmvp/consts/Parameter.java
+++ b/src/main/java/app/linguistai/bmvp/consts/Parameter.java
@@ -2,4 +2,5 @@ package app.linguistai.bmvp.consts;
 
 public class Parameter {
     public static final String ASCENDING_ORDER = "asc";
+    public static final boolean ALLOW_ADDING_NON_DICTIONARY_WORDS = false;
 }

--- a/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
@@ -26,6 +26,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static app.linguistai.bmvp.consts.Parameter.ALLOW_ADDING_NON_DICTIONARY_WORDS;
+
 @AllArgsConstructor
 @RestController
 @RequestMapping("wordbank")
@@ -63,8 +65,8 @@ public class UnknownWordController {
     }
 
     @PostMapping("/add-word")
-    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email, @RequestParam(defaultValue = "false") boolean allowUnknown) throws Exception {
-        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email, allowUnknown));
+    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email) throws Exception {
+        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email, ALLOW_ADDING_NON_DICTIONARY_WORDS));
     }
 
     @PostMapping("/increase-confidence")

--- a/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
@@ -63,16 +63,8 @@ public class UnknownWordController {
     }
 
     @PostMapping("/add-word")
-    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email) {
-        try {
-            return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email));
-        }
-        catch (RuntimeException e) {
-            return Response.create(e.getMessage(), HttpStatus.BAD_REQUEST);
-        }
-        catch (Exception e) {
-            return Response.create("Could not add unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email) throws Exception {
+        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email));
     }
 
     @PostMapping("/increase-confidence")

--- a/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
+++ b/src/main/java/app/linguistai/bmvp/controller/UnknownWordController.java
@@ -63,8 +63,8 @@ public class UnknownWordController {
     }
 
     @PostMapping("/add-word")
-    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email) throws Exception {
-        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email));
+    public ResponseEntity<Object> addWord(@Valid @RequestBody QAddUnknownWord qAddUnknownWord, @RequestHeader(Header.USER_EMAIL) String email, @RequestParam(defaultValue = "false") boolean allowUnknown) throws Exception {
+        return Response.create("Successfully added unknown word " + qAddUnknownWord.getWord() + ".", HttpStatus.OK, unknownWordService.addWord(qAddUnknownWord, email, allowUnknown));
     }
 
     @PostMapping("/increase-confidence")

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
@@ -17,7 +17,7 @@ public interface IUnknownWordService {
     RUnknownWordListWords getListWithWordsById(UUID listId, String email) throws Exception;
     ROwnerUnknownWordList createList(QUnknownWordList qUnknownWordList, String email) throws Exception;
     ROwnerUnknownWordList editList(UUID listId, QUnknownWordList qUnknownWordList, String email) throws Exception;
-    RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowUnknown) throws Exception;
+    RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowNonDictionaryWords) throws Exception;
     RUnknownWord increaseConfidence(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
     RUnknownWord decreaseConfidence(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
     ROwnerUnknownWordList activateList(UUID listId, String email) throws Exception;

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/IUnknownWordService.java
@@ -17,7 +17,7 @@ public interface IUnknownWordService {
     RUnknownWordListWords getListWithWordsById(UUID listId, String email) throws Exception;
     ROwnerUnknownWordList createList(QUnknownWordList qUnknownWordList, String email) throws Exception;
     ROwnerUnknownWordList editList(UUID listId, QUnknownWordList qUnknownWordList, String email) throws Exception;
-    RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
+    RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowUnknown) throws Exception;
     RUnknownWord increaseConfidence(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
     RUnknownWord decreaseConfidence(QAddUnknownWord qAddUnknownWord, String email) throws Exception;
     ROwnerUnknownWordList activateList(UUID listId, String email) throws Exception;

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
@@ -292,7 +292,7 @@ public class UnknownWordService implements IUnknownWordService {
                 throw new NotFoundException(String.format("It looks like %s isn't in our dictionary yet. Please double-check your spelling.", qAddUnknownWord.getWord()));
             }
             log.error("Dictionary service returned an error:" + e.getMessage());
-            throw new SomethingWentWrongException();
+            throw new SomethingWentWrongException("We had trouble communicating with our dictionary service, please try again later.");
         } catch (RuntimeException e) {
             log.error(e.getMessage());
             throw new AlreadyFoundException(e.getMessage());

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
@@ -60,17 +60,17 @@ public class UnknownWordService implements IUnknownWordService {
 
     private final int MODIFY_WORD_CONFIDENCE_DOWN = 2002;
 
-    private WebClient webClient;
-    private final WebClient.Builder webClientBuilder;
+    private WebClient dictionaryWebClient;
+    private final WebClient.Builder dictionaryWebClientBuilder;
 
     @Value("${dict.service.base.url}")
     private String DICT_SERVICE_BASE_URL;
 
-    private WebClient getWebClient() {
-        if (webClient == null) {
-            webClient = webClientBuilder.baseUrl(DICT_SERVICE_BASE_URL).build();
+    private WebClient getDictionaryWebClient() {
+        if (dictionaryWebClient == null) {
+            dictionaryWebClient = dictionaryWebClientBuilder.baseUrl(DICT_SERVICE_BASE_URL).build();
         }
-        return webClient;
+        return dictionaryWebClient;
     }
 
     @Override
@@ -242,7 +242,7 @@ public class UnknownWordService implements IUnknownWordService {
 
     @Override
     @Transactional
-    public RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email) throws Exception {
+    public RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowUnknown) throws Exception {
         try {
             // Check if dictionary service base URL is set
             if (DICT_SERVICE_BASE_URL == null || DICT_SERVICE_BASE_URL.isEmpty()) {
@@ -263,16 +263,18 @@ public class UnknownWordService implements IUnknownWordService {
                 throw new RuntimeException("Word " + qAddUnknownWord.getWord().toLowerCase() + " already exists in list " + userList.getTitle() + ".");
             });
 
-            // Call dictionary service
-            Map<String, Object> requestBody = new HashMap<>();
-            requestBody.put("wordList", Collections.singletonList(qAddUnknownWord.getWord().toLowerCase()));
+            // Call dictionary service only if allowUnknown is false
+            if (!allowUnknown) {
+                Map<String, Object> requestBody = new HashMap<>();
+                requestBody.put("wordList", Collections.singletonList(qAddUnknownWord.getWord().toLowerCase()));
 
-            this.getWebClient().post()
-                .header(Header.USER_EMAIL, email)
-                .body(Mono.just(requestBody), Map.class)
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
+                this.getDictionaryWebClient().post()
+                        .header(Header.USER_EMAIL, email)
+                        .body(Mono.just(requestBody), Map.class)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .block();
+            }
 
             // Create and save new unknown word
             UnknownWord newWord = UnknownWord.builder()
@@ -287,7 +289,7 @@ public class UnknownWordService implements IUnknownWordService {
         } catch (WebClientResponseException e) {
             if (e.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
                 log.error("Word {} is not found in the dictionary.", qAddUnknownWord.getWord());
-                throw new NotFoundException("Word is not found in the dictionary.");
+                throw new NotFoundException(String.format("Word %s is not valid.", qAddUnknownWord.getWord()));
             }
             log.error("Dictionary service returned an error:" + e.getMessage());
             throw new SomethingWentWrongException();

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
@@ -242,7 +242,7 @@ public class UnknownWordService implements IUnknownWordService {
 
     @Override
     @Transactional
-    public RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowUnknown) throws Exception {
+    public RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email, boolean allowNonDictionaryWords) throws Exception {
         try {
             // Check if dictionary service base URL is set
             if (DICT_SERVICE_BASE_URL == null || DICT_SERVICE_BASE_URL.isEmpty()) {
@@ -263,8 +263,8 @@ public class UnknownWordService implements IUnknownWordService {
                 throw new RuntimeException("Word " + qAddUnknownWord.getWord().toLowerCase() + " already exists in list " + userList.getTitle() + ".");
             });
 
-            // Call dictionary service only if allowUnknown is false
-            if (!allowUnknown) {
+            // Call dictionary service only if allowNonDictionaryWords is false
+            if (!allowNonDictionaryWords) {
                 Map<String, Object> requestBody = new HashMap<>();
                 requestBody.put("wordList", Collections.singletonList(qAddUnknownWord.getWord().toLowerCase()));
 

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
@@ -1,5 +1,7 @@
 package app.linguistai.bmvp.service.wordbank;
 
+import app.linguistai.bmvp.consts.Header;
+import app.linguistai.bmvp.exception.AlreadyFoundException;
 import app.linguistai.bmvp.exception.NotFoundException;
 import app.linguistai.bmvp.exception.SomethingWentWrongException;
 import app.linguistai.bmvp.exception.UnauthorizedException;
@@ -22,8 +24,13 @@ import app.linguistai.bmvp.request.wordbank.QUnknownWordList;
 import app.linguistai.bmvp.response.wordbank.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.http.HttpStatus;
+import reactor.core.publisher.Mono;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -52,6 +59,19 @@ public class UnknownWordService implements IUnknownWordService {
     private final int MODIFY_WORD_CONFIDENCE_UP = 2001;
 
     private final int MODIFY_WORD_CONFIDENCE_DOWN = 2002;
+
+    private WebClient webClient;
+    private final WebClient.Builder webClientBuilder;
+
+    @Value("${dict.service.base.url}")
+    private String DICT_SERVICE_BASE_URL;
+
+    private WebClient getWebClient() {
+        if (webClient == null) {
+            webClient = webClientBuilder.baseUrl(DICT_SERVICE_BASE_URL).build();
+        }
+        return webClient;
+    }
 
     @Override
     @Transactional
@@ -224,6 +244,12 @@ public class UnknownWordService implements IUnknownWordService {
     @Transactional
     public RUnknownWord addWord(QAddUnknownWord qAddUnknownWord, String email) throws Exception {
         try {
+            // Check if dictionary service base URL is set
+            if (DICT_SERVICE_BASE_URL == null || DICT_SERVICE_BASE_URL.isEmpty()) {
+                throw new IllegalStateException("Dict Service Base URL is not set. Word addition is not allowed.");
+            }
+
+            // Retrieve user's word list
             UnknownWordListWithUser userListInfo = this.getUserOwnedList(qAddUnknownWord.getListId(), email);
             UnknownWordList userList = userListInfo.list();
 
@@ -237,7 +263,18 @@ public class UnknownWordService implements IUnknownWordService {
                 throw new RuntimeException("Word " + qAddUnknownWord.getWord().toLowerCase() + " already exists in list " + userList.getTitle() + ".");
             });
 
-            // If the word does not exist in the list, build new unknown word
+            // Call dictionary service
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("wordList", Collections.singletonList(qAddUnknownWord.getWord().toLowerCase()));
+
+            this.getWebClient().post()
+                .header(Header.USER_EMAIL, email)
+                .body(Mono.just(requestBody), Map.class)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+            // Create and save new unknown word
             UnknownWord newWord = UnknownWord.builder()
                 .ownerList(userList)
                 .word(qAddUnknownWord.getWord().toLowerCase())
@@ -247,9 +284,18 @@ public class UnknownWordService implements IUnknownWordService {
             UnknownWord saved = wordRepository.save(newWord);
 
             return RUnknownWord.builder().word(saved.getWord().toLowerCase()).confidence(saved.getConfidence()).build();
-        }
-        catch (Exception e1) {
-            log.error("Could not add unknown word.");
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
+                log.error("Word {} is not found in the dictionary.", qAddUnknownWord.getWord());
+                throw new NotFoundException("Word is not found in the dictionary.");
+            }
+            log.error("Dictionary service returned an error:" + e.getMessage());
+            throw new SomethingWentWrongException();
+        } catch (RuntimeException e) {
+            log.error(e.getMessage());
+            throw new AlreadyFoundException(e.getMessage());
+        } catch (Exception e) {
+            log.error("Could not add unknown word: " + e.getMessage());
             throw new SomethingWentWrongException();
         }
     }

--- a/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
+++ b/src/main/java/app/linguistai/bmvp/service/wordbank/UnknownWordService.java
@@ -289,7 +289,7 @@ public class UnknownWordService implements IUnknownWordService {
         } catch (WebClientResponseException e) {
             if (e.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
                 log.error("Word {} is not found in the dictionary.", qAddUnknownWord.getWord());
-                throw new NotFoundException(String.format("Word %s is not valid.", qAddUnknownWord.getWord()));
+                throw new NotFoundException(String.format("It looks like %s isn't in our dictionary yet. Please double-check your spelling.", qAddUnknownWord.getWord()));
             }
             log.error("Dictionary service returned an error:" + e.getMessage());
             throw new SomethingWentWrongException();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,7 @@ spring.jwt.refresh.expiration=${JWT_REFRESH_VALID_MINUTES}
 
 ml.service.base.url=${ML_SERVICE_BASE_URL}
 aws.service.base.url=${AWS_SERVICE_BASE_URL}
+dict.service.base.url=${DICT_SERVICE_BASE_URL}
 
 # Level configs
 xp.values.message=1

--- a/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
+++ b/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
@@ -376,7 +376,7 @@ class UnknownWordServiceTest {
         when(accountRepository.findUserByEmail("email")).thenReturn(Optional.empty());
 
         // Run the test
-        assertThatThrownBy(() -> unknownWordService.addWord(qAddUnknownWord, "email"))
+        assertThatThrownBy(() -> unknownWordService.addWord(qAddUnknownWord, "email", true))
             .isInstanceOf(Exception.class);
     }
 
@@ -399,7 +399,7 @@ class UnknownWordServiceTest {
             .thenReturn(Optional.empty());
 
         // Run the test
-        assertThatThrownBy(() -> unknownWordService.addWord(qAddUnknownWord, "email"))
+        assertThatThrownBy(() -> unknownWordService.addWord(qAddUnknownWord, "email", true))
             .isInstanceOf(Exception.class);
     }
 

--- a/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
+++ b/src/test/java/app/linguistai/bmvp/service/wordbank/UnknownWordServiceTest.java
@@ -12,11 +12,14 @@ import app.linguistai.bmvp.repository.wordbank.IUnknownWordRepository;
 import app.linguistai.bmvp.request.wordbank.QAddUnknownWord;
 import app.linguistai.bmvp.request.wordbank.QUnknownWordList;
 import app.linguistai.bmvp.response.wordbank.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +43,13 @@ class UnknownWordServiceTest {
     private IUnknownWordListRepository listRepository;
     @Mock
     private IAccountRepository accountRepository;
+
+    private static final String DICT_SERVICE_BASE_URL = "http://example.com/dictionary";
+
+    @BeforeEach
+    public void setUp() {
+        ReflectionTestUtils.setField(unknownWordService, "DICT_SERVICE_BASE_URL", DICT_SERVICE_BASE_URL);
+    }
 
     @Test
     void testGetListsByEmail() throws Exception {


### PR DESCRIPTION
Dictionary service's responses are logged. For example, for the 404 error, this is logged: 

`Word kjjj is not found in the dictionary. Dictionary service's error: {"error":"error","msg":"Word not found: kjjj","timestamp":"2024-05-16T04:57:21+03:00","status":404}`

Similarly, all other responses log the dictionary response. 

To parse the response, I tried .onStatus and exchangeFilterResponseProcessor methods, but if we throw a `Mono.error(new NotFoundException(body))` then this error is caught in the catch(RuntimeError) block, not the NotFoundError block, since Mono errors are thrown as RuntimeError's children errors within the WebClient's reactive chain. 

Instead, we parse the exception that is mentioned here: https://www.baeldung.com/spring-5-webclient#4-getting-a-response

I looked at the following solutions:
https://www.baeldung.com/spring-webclient-get-response-body
https://stackoverflow.com/questions/76057817/the-type-httpstatus-does-not-define-iserrorhttpstatuscode-defined-here-in-java
https://www.baeldung.com/spring-webflux-errors
https://stackoverflow.com/questions/63701274/how-to-get-custom-error-body-message-in-webclient-properly

There might be better solutions out there, but this now logs the dictionary response.

NOTE: Do NOT merge this PR before the dev to main PR, since this code **will** cause errors and this PR is just to be able to log in more detail, it does not actually solve the problem. 

